### PR TITLE
Issue4.awinters.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "ng": "ng",
     "start": "ng build @senzing/sdk-graph-components && ng serve",
     "start:docs": "npx compodoc -s --port 6300 -d ./docs",
+    "start:server": "java -jar \"../senzing-api-server/target/senzing-api-server-1.6.1.jar\" -httpPort 8080 -bindAddr all -iniFile \"%LOCALAPPDATA%\\Senzing\\Workbench\\project_1\\g2.ini\" -allowedOrigins \"*\"",
     "build": "ng build @senzing/sdk-graph-components && node build-package.js",
     "build:docs": "npx compodoc -p src/tsconfig.lib.json -n \"Senzing SDK Graph Components\" -d ./docs --disableInternal --disablePrivate --disableDomTree --disableGraph --disableRoutesGraph --disableCoverage --disableSourceCode && node build-docs",
     "e2e": "ng e2e",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sdk-graph-components",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "private": false,
   "keywords": [
     "Angular",

--- a/src/lib/graph/sz-relationship-network/sz-relationship-network.component.html
+++ b/src/lib/graph/sz-relationship-network/sz-relationship-network.component.html
@@ -2,4 +2,5 @@
   <svg data-html2canvas-ignore #graphEle class="graph-chart"
   [attr.viewBox]="this.svgViewBox"
   [attr.preserveAspectRatio]="this.svgPreserveAspectRatio"
+  (contextmenu)="onRightClick($event)"
   ></svg>

--- a/src/lib/graph/sz-relationship-network/sz-relationship-network.component.ts
+++ b/src/lib/graph/sz-relationship-network/sz-relationship-network.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, HostBinding, OnInit, ViewChild, AfterViewInit } from '@angular/core';
+import { Component, Input, HostBinding, OnInit, ViewChild, AfterViewInit, Output, EventEmitter } from '@angular/core';
 import * as d3 from 'd3';
 import { Graph, NodeInfo, LinkInfo } from './graph-types';
 import { Simulation } from 'd3-force';
@@ -160,6 +160,20 @@ export class SzRelationshipNetworkComponent implements OnInit, AfterViewInit {
    * return the raw data node in the payload
    */
   static readonly WITH_RAW: boolean = true;
+
+  /**
+   * nulls out the browser right click menu
+   * @param event
+   */
+  public onRightClick(event: any) {
+    return false;
+  }
+
+  /**
+   * emitted when the player right clicks a entity node.
+   * @returns object with various entity and ui properties.
+   */
+  @Output() contextMenuClick: EventEmitter<any> = new EventEmitter<any>();
 
   node;
   nodeLabel;
@@ -366,17 +380,18 @@ export class SzRelationshipNetworkComponent implements OnInit, AfterViewInit {
         .style("left", (d3.event.pageX) + "px")
         .style("top", (d3.event.pageY + 10) + "px");
     })
-      .on('mouseover.fade', this.fade(0.1).bind(this))
-      .on("mouseout.tooltip", function () {
-        tooltip.transition()
-          .duration(100)
-          .style("opacity", 0);
-      })
-      .on('mouseout.fade', this.fade(1).bind(this))
-      .on("mousemove", function () {
-        tooltip.style("left", (d3.event.pageX) + "px")
-          .style("top", (d3.event.pageY + 10) + "px");
-      });
+    .on('mouseover.fade', this.fade(0.1).bind(this))
+    .on("mouseout.tooltip", function () {
+      tooltip.transition()
+        .duration(100)
+        .style("opacity", 0);
+    })
+    .on('mouseout.fade', this.fade(1).bind(this))
+    .on("mousemove", function () {
+      tooltip.style("left", (d3.event.pageX) + "px")
+        .style("top", (d3.event.pageY + 10) + "px");
+    })
+    .on('contextmenu', this.onNodeContextClick.bind(this));
 
     // Make the tooltip visible when mousing over links.  Fade out distant nodes
     this.link.on('mouseover.fade', this.linkFade(0.1).bind(this))
@@ -426,6 +441,16 @@ export class SzRelationshipNetworkComponent implements OnInit, AfterViewInit {
     return this.linkedByNodeIndexMap[`${a.index},${b.index}`] ||
       this.linkedByNodeIndexMap[`${b.index},${a.index}`] ||
       a.index === b.index;
+  }
+
+  /**
+   * handler for when a entity node is right clicked.
+   * proxies to synthetic event "contextMenuClick"
+   * @param event
+   */
+  onNodeContextClick(event: any) {
+    this.contextMenuClick.emit(event);
+    return false;
   }
 
   /**

--- a/src/lib/graph/sz-relationship-network/sz-relationship-network.component.ts
+++ b/src/lib/graph/sz-relationship-network/sz-relationship-network.component.ts
@@ -175,6 +175,18 @@ export class SzRelationshipNetworkComponent implements OnInit, AfterViewInit {
    */
   @Output() contextMenuClick: EventEmitter<any> = new EventEmitter<any>();
 
+  /**
+   * emitted when the player clicks a entity node.
+   * @returns object with various entity and ui properties.
+   */
+  @Output() entityClick: EventEmitter<any> = new EventEmitter<any>();
+
+  /**
+   * emitted when the user dbl-clicks a entity node.
+   * @returns object with various entity and ui properties.
+   */
+  @Output() entityDblClick: EventEmitter<any> = new EventEmitter<any>();
+
   node;
   nodeLabel;
   link;
@@ -391,6 +403,8 @@ export class SzRelationshipNetworkComponent implements OnInit, AfterViewInit {
       tooltip.style("left", (d3.event.pageX) + "px")
         .style("top", (d3.event.pageY + 10) + "px");
     })
+    .on('click', this.onNodeClick.bind(this))
+    .on('dblclick', this.onNodeDblClick.bind(this))
     .on('contextmenu', this.onNodeContextClick.bind(this));
 
     // Make the tooltip visible when mousing over links.  Fade out distant nodes
@@ -443,6 +457,23 @@ export class SzRelationshipNetworkComponent implements OnInit, AfterViewInit {
       a.index === b.index;
   }
 
+  /**
+   * handler for when a entity node is clicked.
+   * proxies to synthetic event "entityClick"
+   * @param event
+   */
+  onNodeClick(event: any) {
+    this.entityClick.emit(event);
+  }
+  /**
+   * handler for when a entity node is double clicked.
+   * proxies to synthetic event "entityDblClick"
+   * @param event
+   */
+  onNodeDblClick(event: any) {
+    this.entityDblClick.emit(event);
+    return false;
+  }
   /**
    * handler for when a entity node is right clicked.
    * proxies to synthetic event "contextMenuClick"

--- a/src/package.json
+++ b/src/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@senzing/sdk-graph-components",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "dependencies": {
     "@senzing/rest-api-client-ng": "^1.0.2"
   },

--- a/test/app/app.component.html
+++ b/test/app/app.component.html
@@ -10,6 +10,7 @@
   entityIds="1,1005"
   maxDegrees=3
   buildOut=2
+  (contextMenuClick)="onContextMenuClick($event)"
   maxEntities=1000>
   </sz-relationship-network>
 </div>

--- a/test/app/app.component.ts
+++ b/test/app/app.component.ts
@@ -7,4 +7,8 @@ import { Component } from '@angular/core';
 })
 export class AppComponent {
   title = 'sdk-graph-components';
+
+  public onContextMenuClick(event: any) {
+    console.log('Context Menu Click for: ', event);
+  }
 }


### PR DESCRIPTION
#4. Added the following synthetic events to src/lib/graph/sz-relationship-network/sz-relationship-network.component.ts

* contextMenuClick
* entityClick
* entityDblClick

these events allow for bubbling up D3 click events on a graph to the component consumer. when a user clicks on a entity node in the graph embedded in the page or in another component, the app can then bind it's own event handlers to the specific event.