### PR TITLE
add new "no results" events

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sdk-graph-components",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "private": false,
   "keywords": [
     "Angular",

--- a/src/lib/graph/sz-relationship-network/sz-relationship-network.component.ts
+++ b/src/lib/graph/sz-relationship-network/sz-relationship-network.component.ts
@@ -57,6 +57,8 @@ export class SzRelationshipNetworkComponent implements OnInit, AfterViewInit, On
   private _requestComplete: Subject<boolean> = new Subject<boolean>();
   /** @internal */
   private _renderComplete: Subject<boolean> = new Subject<boolean>();
+  /** @internal */
+  private _requestNoResults: Subject<boolean> = new Subject<boolean>();
 
   /**
    * Observeable stream for the event that occurs when a network
@@ -73,6 +75,16 @@ export class SzRelationshipNetworkComponent implements OnInit, AfterViewInit, On
    * operation is completed
    */
   public renderComplete: Observable<boolean>;
+  /**
+   * Observeable stream for the event that occurs when a
+   * request completed but has no results
+   */
+  public requestNoResults: Observable<boolean>;
+  /**
+   * emitted when the player right clicks a entity node.
+   * @returns object with various entity and ui properties.
+   */
+  @Output() noResults: EventEmitter<boolean> = new EventEmitter<boolean>();
 
 
   // assigned during render phase to D3 selector groups
@@ -271,6 +283,7 @@ export class SzRelationshipNetworkComponent implements OnInit, AfterViewInit, On
     this.requestStarted = this._requestStarted.asObservable();
     this.requestComplete = this._requestComplete.asObservable();
     this.renderComplete = this._renderComplete.asObservable();
+    this.requestNoResults = this._requestNoResults.asObservable();
   }
 
   ngOnInit() {
@@ -291,6 +304,10 @@ export class SzRelationshipNetworkComponent implements OnInit, AfterViewInit, On
         map(this.asGraph.bind(this)),
         tap( (gdata: Graph) => {
           console.log('SzRelationshipNetworkGraph: g1 = ', gdata);
+          if(gdata.links.length == 0) {
+            this.noResults.emit(true);
+            this._requestNoResults.next(true);
+          }
         })
       ).subscribe( this.addSvg.bind(this) );
     }

--- a/src/package.json
+++ b/src/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@senzing/sdk-graph-components",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "dependencies": {
     "@senzing/rest-api-client-ng": "^1.0.2"
   },


### PR DESCRIPTION
# Pull request questions

## Which issue does this address
#16 

## Why was change needed
to notify any consuming apps when the result of a graph find network query returns "0" relationships.

![2019-08-29_175233](https://user-images.githubusercontent.com/13721038/63995018-a7815480-caab-11e9-80d9-bd05eafe0e3d.png)


## What does change improve
allows applications to provide no-results messaging, hide things etc. Is necessary for fixing https://github.com/senzingiris/sdk-components-ng/issues/90
