### PR TITLE
#56 fix for entities with no relationships

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 [markdownlint](https://dlaa.me/markdownlint/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.1.3] - 2021-1-26
+
+- Bugfix for #56. There was a change to data models that changed the `relatedEntities` node from `[]` to omitted entirely when not present. The code needed to be updated to run safety checks to avoid script errors when an entity has no relationships.
+
+relevant tickets: #56
+
 ## [2.1.2] - 2020-10-30
 
 - API Client package updated to the [Senzing OAS 2.2.0](https://github.com/Senzing/senzing-rest-api-specification/releases/tag/2.2.0) specification.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sdk-graph-components",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "private": false,
   "keywords": [
     "Angular",

--- a/src/lib/graph/sz-relationship-network/sz-relationship-network.component.ts
+++ b/src/lib/graph/sz-relationship-network/sz-relationship-network.component.ts
@@ -1222,9 +1222,9 @@ export class SzRelationshipNetworkComponent implements OnInit, AfterViewInit, On
     // Add a node for each resolved entity
     entitiesData.forEach(entNode => {
       const resolvedEntity  = entNode.resolvedEntity;
-      const relatedEntRels  = entNode.relatedEntities.filter( (relEnt) => {
+      const relatedEntRels  = entNode.relatedEntities && entNode.relatedEntities.filter ? entNode.relatedEntities.filter( (relEnt) => {
         return primaryEntities ? primaryEntities.indexOf(relEnt.entityId) >= 0 : false;
-      } );
+      } ) : undefined;
 
       //console.log('SzRelationshipNetworkGraph.asGraph: ',
       //relatedEntRels, entNode.relatedEntities);
@@ -1266,7 +1266,7 @@ export class SzRelationshipNetworkComponent implements OnInit, AfterViewInit, On
     // Add links between resolved entities.
     entitiesData.forEach(entityInfo => {
       const entityId = entityInfo.resolvedEntity.entityId;
-      const relatedEntities = entityInfo.relatedEntities;
+      const relatedEntities = entityInfo.relatedEntities && entityInfo.relatedEntities.forEach ? entityInfo.relatedEntities : [];
       relatedEntities.forEach(relatedEntity => {
 
         const relatedEntityId = relatedEntity.entityId;

--- a/src/package.json
+++ b/src/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@senzing/sdk-graph-components",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "dependencies": {
     "tslib": "^2.0.0"
   },


### PR DESCRIPTION
# Pull request questions

## Which issue does this address

resolves #56 
related to https://github.com/Senzing/sdk-components-ng/issues/202

## Why was change needed

There was a change to datamodels that the api server returns. When no relatedEntities returned the node is ommitted entirely. The code needed safety checks to avoid script errors.

## What does change improve

graph doesn't explode when no `relatedEntities` present in the data returned.
