### PR TITLE
#70 added interface for http header passthrough to rest-api-client-ng

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2159,9 +2159,9 @@
       }
     },
     "@senzing/rest-api-client-ng": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@senzing/rest-api-client-ng/-/rest-api-client-ng-2.2.0.tgz",
-      "integrity": "sha512-nZvkHmFHXTBUcihKeleQnQyIDWGOBKojv8AIhBSAYUWHf+oPTH2bdn+a0ZJXacyKbduxo3dV4kqZg/NDA2gC+A==",
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/@senzing/rest-api-client-ng/-/rest-api-client-ng-2.2.2.tgz",
+      "integrity": "sha512-/EOnCfTjIenTFFqgptdGMTwnNFZZbGQmoED+hIkNXfA3V3WZZ2ahCLZLHlQa91UNHy4xwSI0+xqY6Wz377P//g==",
       "requires": {
         "tslib": "^2.0.0"
       }
@@ -7892,7 +7892,8 @@
     "ini": {
       "version": "1.3.8",
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
-      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+      "dev": true
     },
     "injection-js": {
       "version": "2.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sdk-graph-components",
-  "version": "2.1.3",
+  "version": "2.2.0",
   "private": false,
   "keywords": [
     "Angular",
@@ -24,7 +24,9 @@
     "e2e": "ng e2e",
     "e2e:headless": "ng e2e --protractor-config=e2e/protractor.ci.conf.js",
     "lint": "ng lint",
-    "package": "node post-build.js && cd ./dist/@senzing/sdk-graph-components/ && npm pack && cd ../../../",
+    "package": "cd ./dist/@senzing/sdk-graph-components/ && npm pack && cd ../../../",
+    "postbuild": "node post-build.js && npm run package",
+    "postbuild:prod": "npm run postbuild",
     "publish": "cd ./dist/@senzing/sdk-graph-components/ && npm publish --access public",
     "test": "ng test",
     "test:headless": "ng test --no-watch --watch=false --progress=false --no-progress --karmaConfig src/karma.ci.conf.js --browsers=ChromeHeadlessCI",
@@ -40,7 +42,7 @@
     "@angular/platform-browser": "~10.0.9",
     "@angular/platform-browser-dynamic": "~10.0.9",
     "@angular/router": "~10.0.9",
-    "@senzing/rest-api-client-ng": "^2.2.0",
+    "@senzing/rest-api-client-ng": "^2.2.2",
     "@types/d3": "^5.7.2",
     "d3": "^5.9.1",
     "rxjs": "~6.5.5",

--- a/src/lib/services/graph-configuration.service.ts
+++ b/src/lib/services/graph-configuration.service.ts
@@ -1,8 +1,11 @@
 import { Injectable, Output, Input, Inject } from '@angular/core';
 import { Observable, fromEventPattern, Subject } from 'rxjs';
 import { map, tap, mapTo } from 'rxjs/operators';
-import { Configuration as SzRestConfiguration, ConfigurationParameters as SzRestConfigurationParameters } from '@senzing/rest-api-client-ng';
-
+import { 
+  Configuration as SzRestConfiguration, 
+  ConfigurationParameters as SzRestConfigurationParameters 
+} from '@senzing/rest-api-client-ng';
+/*
 import {
   EntityDataService,
   ConfigService,
@@ -11,13 +14,37 @@ import {
   SzAttributeTypesResponse,
   SzAttributeType,
   SzAttributeSearchResult
-} from '@senzing/rest-api-client-ng';
-import { SzEntitySearchParams } from '../models/entity-search';
+} from '@senzing/rest-api-client-ng';*/
+//import { SzEntitySearchParams } from '../models/entity-search';
 
 @Injectable({
   providedIn: 'root'
 })
 export class SzGraphConfigurationService {
+  /** add an additional header to all outgoing API requests */
+  public addHeaderToApiRequests(header: {[key: string]: string}): void {
+    this.apiConfiguration.addAdditionalRequestHeader( header );
+  }
+  /** remove an additional header from all outgoing API requests */
+  public removeHeaderFromApiRequests(header: {[key: string]: string} | string): void {
+    this.apiConfiguration.removeAdditionalRequestHeader( header );
+  }
+  /** 
+   * additional http/https request headers that will be added by default to 
+   * all outbound api server requests.
+   */
+  public get additionalApiRequestHeaders(): {[key: string]: string} | undefined {
+    return this.apiConfiguration.additionalHeaders;
+  }
+  /** 
+   * set additional http/https request headers to be added by default to 
+   * all outbound api server requests. most commonly used for adding custom 
+   * or required non-standard headers like jwt session tokens, auth id etc.
+   */
+  public set additionalApiRequestHeaders(value: {[key: string]: string} | undefined) {
+    this.apiConfiguration.additionalHeaders = value;
+  }
+
   /**
    * emmitted when a property has been changed.
    * used mostly for diagnostics.

--- a/src/package.json
+++ b/src/package.json
@@ -1,13 +1,13 @@
 {
   "name": "@senzing/sdk-graph-components",
-  "version": "2.1.3",
+  "version": "2.2.0",
   "dependencies": {
     "tslib": "^2.0.0"
   },
   "peerDependencies": {
     "@angular/common": "^10.0.14",
     "@angular/core": "^10.0.14",
-    "@senzing/rest-api-client-ng": "^2.2.0",
+    "@senzing/rest-api-client-ng": "^2.2.2",
     "@types/d3": "^5.7.2",
     "d3": "^5.9.1"
   }


### PR DESCRIPTION
# Pull request questions

## Which issue does this address

related #70

## Why was change needed

To facilitate the _option_ for implementations to pass additional HTTP headers to API Server endpoints.

## What does change improve

Passing additional or custom headers are necessary in certain operation scenario's, ie: passing `X-Amz-Security-Token` to a [Cognito](https://aws.amazon.com/cognito/) enabled [API Gateway](https://aws.amazon.com/api-gateway/) address after user authentication.

## Technical Details

- Methods added to SzConfigurationService :
  - addHeaderToApiRequests
  - removeHeaderFromApiRequests
- Accessors added to SzConfigurationService :
  - additionalApiRequestHeaders